### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,8 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/c5473c4c/JWave/security/code-scanning/1](https://github.com/c5473c4c/JWave/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Specifically:
- The `contents: read` permission will be set to allow the workflow to read repository contents.
- Additional permissions will be added only if required by specific steps in the workflow.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. This ensures consistency and avoids redundancy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
