### PR TITLE
Fix decomposition block calculation

### DIFF
--- a/src/main/java/jwave/tools/MathToolKit.java
+++ b/src/main/java/jwave/tools/MathToolKit.java
@@ -112,8 +112,10 @@ public class MathToolKit {
           "Given blockSize is greater than the given number "
               + "to be split by it" );
 
-    int noOfBlocks = number % blockSize; // 127 % 32 = 3
+    // determine how many full blocks fit into the given number
+    int noOfBlocks = number / blockSize; // e.g. 127 / 32 = 3
 
+    // remaining part after taking the blocks
     int rest = number - noOfBlocks * blockSize; // 127 - 3 * 32 = 31
 
     int[ ] ancientEgyptianMultipliers = decompose( rest );


### PR DESCRIPTION
## Summary
- fix calculation of number of blocks in `MathToolKit.decompose`

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68612ff7b920832c9def1ea5d626e2b5